### PR TITLE
escapeForId was removed

### DIFF
--- a/MediaWikiBootstrap.skin.php
+++ b/MediaWikiBootstrap.skin.php
@@ -229,7 +229,7 @@ class MediaWikiBootstrapTemplate extends BaseTemplate {
                                     <ul class="nav navbar-nav navbar-right">
                                         <?php
                                         foreach ( $this->getSidebar() as $boxName => $box ) { ?>
-                                            <!-- <div id="<?php echo Sanitizer::escapeId( $box['id'] ) ?>"<?php echo Linker::tooltip( $box['id'] ) ?>> -->
+                                            <!-- <div id="<?php echo Sanitizer::escapeIdForAttribute( $box['id'] ) ?>"<?php echo Linker::tooltip( $box['id'] ) ?>> -->
                                                 <!-- <h5><?php echo htmlspecialchars( $box['header'] ); ?></h5> -->
                                                 <!-- If you do not want the words "Navigation" or "Tools" to appear, you can safely remove the line above. -->
 


### PR DESCRIPTION
Use escapeIdForAttribute instead

escapeForId has been sending deprecation warnings
since 1.30 and removed recently.

To see deprecation warnings please ensure the following is in
LocalSettings.php, it will make development a lot easier.

```
error_reporting( -1 );
ini_set( 'display_errors', 1 );
```
(https://www.mediawiki.org/wiki/Manual:How_to_debug)

This fixes the skin for 1.36 and 1.37