### PR TITLE
Drop VectorUseIconWatch check

### DIFF
--- a/MediaWikiBootstrap.skin.php
+++ b/MediaWikiBootstrap.skin.php
@@ -64,7 +64,6 @@ class MediaWikiBootstrapTemplate extends BaseTemplate {
      */
     public function execute() {
         global $wgGroupPermissions;
-        global $wgVectorUseIconWatch;
         global $wgSearchPlacement;
         global $wgMediaWikiBootstrapSkinLoginLocation;
         global $wgMediaWikiBootstrapSkinAnonNavbar;
@@ -82,18 +81,6 @@ class MediaWikiBootstrapTemplate extends BaseTemplate {
 
         // Build additional attributes for navigation urls
         $nav = $this->data['content_navigation'];
-
-        if ( $wgVectorUseIconWatch ) {
-            $mode = $this->getSkin()->getUser()->isWatched( $this->getSkin()->getRelevantTitle() )
-                    ? 'unwatch'
-                    : 'watch';
-            if ( isset( $nav['actions'][$mode] ) ) {
-                $nav['views'][$mode] = $nav['actions'][$mode];
-                $nav['views'][$mode]['class'] = rtrim( 'icon ' . $nav['views'][$mode]['class'], ' ' );
-                $nav['views'][$mode]['primary'] = true;
-                unset( $nav['actions'][$mode] );
-            }
-        }
 
         $xmlID = '';
         foreach ($nav as $section => $links) {


### PR DESCRIPTION
Vector configuration should not apply to other skins as the
skin may or may not be installed.

Doesn't seem to do anything in this skin and is throwing a fatal
in MediaWiki 1.37 so removing.