### PR TITLE
Remove deprecated ResourceLoaderSkinModule features

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -61,7 +61,19 @@
   "ResourceModules": {
     "skins.mediawikibootstrap": {
       "class": "ResourceLoaderSkinModule",
-      "features": [ "elements", "interface", "content", "logo", "legacy" ],
+      "features": [
+            "elements",
+            "interface",
+            "logo",
+            "content-links",
+            "content-thumbnails",
+            "interface-message-box",
+            "interface-category",
+            "content-tables",
+            "i18n-ordered-lists",
+            "i18n-all-lists-margins",
+            "i18n-headings"
+      ],
       "styles": {
         "css/bootstrap.min.css": { "media": "screen" },
         "css/font-awesome.min.css": { "media": "screen" },


### PR DESCRIPTION
The legacy feature no longer works as of
https://phabricator.wikimedia.org/T304325

Used guidelines in https://www.mediawiki.org/wiki/Manual:ResourceLoaderSkinModule#For_skins_deprecating_the_legacy_feature