### PR TITLE
Ensure thumbnail styles continue to be loaded

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -10,7 +10,7 @@
   ],
   "type": "skin",
   "requires": {
-    "MediaWiki": ">= 1.39.0"
+    "MediaWiki": ">= 1.43.0"
   },
   "manifest_version": 2,
   "ValidSkinNames": {
@@ -62,7 +62,7 @@
         "interface",
         "logo",
         "content-links",
-        "content-thumbnails",
+        "content-media",
         "interface-message-box",
         "interface-category",
         "content-tables",


### PR DESCRIPTION
content-thumbnails is an alias for content-media and will soon be removed.

More information at:
https://phabricator.wikimedia.org/T374262